### PR TITLE
Test/with ms prime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+devel/test_msprime-output : devel/test_msprime.py
+	python devel/test_msprime.py > devel/test_msprime-output

--- a/devel/test_msprime-output.txt
+++ b/devel/test_msprime-output.txt
@@ -1,0 +1,129 @@
+Simulate records.
+Read records into msprime:
+Adjust records
+Read records into msprime:
+--------------------------
+plotting works in c
+{0: 6, 1: 4, 2: 4, 4: 6, 6: -1}
+{0: 6, 1: 4, 2: 4, 3: -1, 4: 6, 5: -1, 6: -1}
+{0: 3, 1: 4, 2: 3, 3: 4, 4: -1}
+{0: 3, 1: 4, 2: 3, 3: 4, 4: -1, 5: -1, 6: -1}
+{0: 5, 1: 4, 2: 4, 4: 5, 5: -1}
+{0: 5, 1: 4, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1}
+	in: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(1, 2), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=6, children=(0, 4), time=1.0, population=0)
+{0: 6, 1: 4, 2: 4, 3: -1, 4: 6, 5: -1, 6: -1}
+[6, 4, 4, -1, 6, -1, -1]
+	out: CoalescenceRecord(left=0.0, right=0.2, node=6, children=(0, 4), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(1, 2), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=3, children=(0, 2), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(1, 3), time=0.5, population=0)
+{0: 3, 1: 4, 2: 3, 3: 4, 4: -1, 5: -1, 6: -1}
+[3, 4, 3, 4, -1, -1, -1]
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(1, 3), time=0.5, population=0)
+	out: CoalescenceRecord(left=0.2, right=0.8, node=3, children=(0, 2), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=4, children=(1, 2), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=5, children=(0, 4), time=0.7, population=0)
+{0: 5, 1: 4, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1}
+[5, 4, 4, -1, 5, -1, -1]
+Can have partial tips?
+--------------------------
+plotting trees fails.
+	in: CoalescenceRecord(left=0.0, right=0.2, node=3, children=(2, 7), time=0.4, population=0)
+python fails.
+list assignment index out of range
+Can have partial tips, if numbered increasing towards root(s)?
+--------------------------
+	in: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.0, right=1.0, node=5, children=(1, 4), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 5), time=1.0, population=0)
+{0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1}
+[7, 5, 4, 4, 5, 7, -1, -1]
+	out: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 5), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+{0: 4, 1: 5, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1, 7: -1}
+[4, 5, 4, -1, 5, -1, -1, -1]
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=6, children=(0, 5), time=0.7, population=0)
+{0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}
+[6, 5, 4, 4, 5, 6, -1, -1]
+fails in c with
+   Bad coalescence records in file, _12.
+Can have unsampled tips, if numbered increasing towards root(s)?
+--------------------------
+	in: CoalescenceRecord(left=0.0, right=0.2, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.0, right=1.0, node=6, children=(1, 5), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=8, children=(0, 6), time=1.0, population=0)
+([8, 6, 5, 5, -1, 6, 8, -1, -1], [[], [], [], [], [], (2, 3), (1, 5), [], (0, 6)])
+	out: CoalescenceRecord(left=0.0, right=0.2, node=8, children=(0, 6), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 3), time=0.2, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=5, children=(2, 4), time=0.4, population=0)
+([4, 6, 5, 4, 5, 6, -1, -1, -1], [[], [], [], [], (0, 3), (2, 4), (1, 5), [], []])
+	out: CoalescenceRecord(left=0.2, right=0.8, node=5, children=(2, 4), time=0.4, population=0)
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 3), time=0.2, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=7, children=(0, 6), time=0.7, population=0)
+([7, 6, 5, 5, -1, 6, 7, -1, -1], [[], [], [], [], [], (2, 3), (1, 5), (0, 6), []])
+{0: 8, 1: 6, 2: 5, 3: 5, 5: 6, 6: 8, 8: -1}
+{0: 8, 1: 6, 2: 5, 3: 5, 4: -1, 5: 6, 6: 8, 7: -1, 8: -1}
+{0: 4, 1: 6, 2: 5, 3: 4, 4: 5, 5: 6, 6: -1}
+{0: 4, 1: 6, 2: 5, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1, 8: -1}
+{0: 7, 1: 6, 2: 5, 3: 5, 5: 6, 6: 7, 7: -1}
+{0: 7, 1: 6, 2: 5, 3: 5, 4: -1, 5: 6, 6: 7, 7: -1, 8: -1}
+	in: CoalescenceRecord(left=0.0, right=0.2, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.0, right=1.0, node=6, children=(1, 5), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=8, children=(0, 6), time=1.0, population=0)
+{0: 8, 1: 6, 2: 5, 3: 5, 4: -1, 5: 6, 6: 8, 7: -1, 8: -1}
+[8, 6, 5, 5, -1, 6, 8, -1, -1]
+	out: CoalescenceRecord(left=0.0, right=0.2, node=8, children=(0, 6), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 3), time=0.2, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=5, children=(2, 4), time=0.4, population=0)
+{0: 4, 1: 6, 2: 5, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1, 8: -1}
+[4, 6, 5, 4, 5, 6, -1, -1, -1]
+	out: CoalescenceRecord(left=0.2, right=0.8, node=5, children=(2, 4), time=0.4, population=0)
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 3), time=0.2, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=5, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=7, children=(0, 6), time=0.7, population=0)
+{0: 7, 1: 6, 2: 5, 3: 5, 4: -1, 5: 6, 6: 7, 7: -1, 8: -1}
+[7, 6, 5, 5, -1, 6, 7, -1, -1]
+Can have coalescence records with the same parent referring to different times?
+--------------------------
+	in: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.0, right=1.0, node=5, children=(1, 4), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 5), time=1.0, population=0)
+{0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 7, 6: -1, 7: -1}
+[7, 5, 4, 4, 5, 7, -1, -1]
+	out: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 5), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+{0: 4, 1: 5, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1, 7: -1}
+[4, 5, 4, -1, 5, -1, -1, -1]
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=6, children=(0, 5), time=0.7, population=0)
+{0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}
+[6, 5, 4, 4, 5, 6, -1, -1]
+Can have single-offspring coalescence records?
+--------------------------
+Must be >= 2 children
+	in: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.0, right=1.0, node=5, children=(1, 4), time=0.5, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=6, children=(5,), time=0.7, population=0)
+	in: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 6), time=1.0, population=0)
+{0: 7, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: 7, 7: -1}
+[7, 5, 4, 4, 5, 6, 7, -1]
+	out: CoalescenceRecord(left=0.0, right=0.2, node=7, children=(0, 6), time=1.0, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=6, children=(5,), time=0.7, population=0)
+	out: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+{0: 4, 1: 5, 2: 4, 3: -1, 4: 5, 5: -1, 6: -1, 7: -1}
+[4, 5, 4, -1, 5, -1, -1, -1]
+	out: CoalescenceRecord(left=0.2, right=0.8, node=4, children=(0, 2), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=4, children=(2, 3), time=0.4, population=0)
+	in: CoalescenceRecord(left=0.8, right=1.0, node=6, children=(0, 5), time=0.7, population=0)
+{0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}
+[6, 5, 4, 4, 5, 6, -1, -1]

--- a/devel/test_msprime-output.txt
+++ b/devel/test_msprime-output.txt
@@ -28,7 +28,6 @@ plotting works in c
 [5, 4, 4, -1, 5, -1, -1]
 Can have partial tips?
 --------------------------
-plotting trees fails.
 	in: CoalescenceRecord(left=0.0, right=0.2, node=3, children=(2, 7), time=0.4, population=0)
 python fails.
 list assignment index out of range
@@ -49,8 +48,6 @@ Can have partial tips, if numbered increasing towards root(s)?
 	in: CoalescenceRecord(left=0.8, right=1.0, node=6, children=(0, 5), time=0.7, population=0)
 {0: 6, 1: 5, 2: 4, 3: 4, 4: 5, 5: 6, 6: -1, 7: -1}
 [6, 5, 4, 4, 5, 6, -1, -1]
-fails in c with
-   Bad coalescence records in file, _12.
 Can have unsampled tips, if numbered increasing towards root(s)?
 --------------------------
 	in: CoalescenceRecord(left=0.0, right=0.2, node=5, children=(2, 3), time=0.4, population=0)
@@ -109,7 +106,6 @@ Can have coalescence records with the same parent referring to different times?
 [6, 5, 4, 4, 5, 6, -1, -1]
 Can have single-offspring coalescence records?
 --------------------------
-Must be >= 2 children
 	in: CoalescenceRecord(left=0.0, right=0.2, node=4, children=(2, 3), time=0.4, population=0)
 	in: CoalescenceRecord(left=0.0, right=1.0, node=5, children=(1, 4), time=0.5, population=0)
 	in: CoalescenceRecord(left=0.0, right=0.2, node=6, children=(5,), time=0.7, population=0)


### PR DESCRIPTION
The changes in `msprime` to allow single-child records (in 20e6af9 of msprime master) fix some of our problems. Yay! 

We have yet to test subset with our attempts, but should use the branch in https://github.com/jeromekelleher/msprime/pull/90 to do this.

Thanks @jeromekelleher 