### PR TITLE
Simpler config to avoid upload of coverage w/ failing test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,17 +39,10 @@ jobs:
           name: Run tests || report coverage
           command: |
             source activate ftprime
-            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests/unit || FAILED="TRUE"
-            if [[ -z "$FAILED" ]] ; then       
-               bash <(curl -s https://codecov.io/bash) -c -F unit;
-            fi
-            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests || FAILED="TRUE"
-            if [[ -z "$FAILED" ]] ; then
-               bash <(curl -s https://codecov.io/bash) -c
-               exit 0;
-            else
-               exit 1;
-            fi
+            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests
+            bash <(curl -s https://codecov.io/bash) -c
+            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests/unit
+            bash <(curl -s https://codecov.io/bash) -c -F unit;
       - store_test_results:
           path: "/tmp/test-reports"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,17 @@ jobs:
             source activate ftprime
             pip install -e .
       - run:
-          name: Run tests || report coverage
+          name: Run unit tests && report coverage
+          command: |
+            source activate ftprime
+            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests/unit
+            bash <(curl -s https://codecov.io/bash) -c -F unit;
+      - run:
+          name: Run all tests && report coverage
           command: |
             source activate ftprime
             pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests
             bash <(curl -s https://codecov.io/bash) -c
-            pytest --junitxml=/tmp/test-reports/pytest.xml --cov-report html:/tmp/test-reports --cov=ftprime tests/unit
-            bash <(curl -s https://codecov.io/bash) -c -F unit;
       - store_test_results:
           path: "/tmp/test-reports"
       - store_artifacts:


### PR DESCRIPTION
removes the env vars set in 17f2ab57b346825b2d482d1892eaabdd2e587af4
(these were originally introduced to *ensure* uploading of coverage with
failed tests, which I now want to *avoid*)