### PR TITLE
added tables input to argrecorder

### DIFF
--- a/ftprime/recomb_collector.py
+++ b/ftprime/recomb_collector.py
@@ -45,7 +45,7 @@ class RecombCollector:
 
         haploid_node_ids = {self.i2c(x[0], x[1]):node_ids[(x[0], x[1])] 
                             for x in node_ids}
-        self.args = ARGrecorder(ts, node_ids=haploid_node_ids)
+        self.args = ARGrecorder(node_ids=haploid_node_ids, ts=ts)
         # will record IDs of diploid samples here when they are chosen
         # but note we don't keep anything else about them here (time, location)
         # as this is recorded by the ARGrecorder

--- a/tests/test_arg_recorder.py
+++ b/tests/test_arg_recorder.py
@@ -239,7 +239,6 @@ class ExplicitTestCase(FtprimeTestCase):
         arg_ids = {k:arg.node_ids[self.ids[k]] for k in self.ids}
         self.assertEqual(arg.nodes.num_rows, len(self.ids))
         self.assertEqual(arg.max_time, 5.0)
-        self.assertEqual(arg.sequence_length, 1.0)
         for x in self.ids:
             self.assertEqual(arg.nodes.time[arg_ids[x]], 5.0 - self.true_times[self.ids[x]])
             if x in self.sample_ids:


### PR DESCRIPTION
This provides a convenient way to let someone start an *empty* argrecorder.  The only change is that all args should be keyword args now (rearranged the order a bit to `__init__()`.)  In particular, passing `ts=msprime.simulate(10)` still works.

Closes #39.